### PR TITLE
Fix TS type translation issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/*
 .vscode
 test_build/
 node_modules/
+*.tgz

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rbxts/luaquaternion",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "A quaternion library for Roblox",
   "keywords": [
     "quaternion",

--- a/src/Quaternion.d.ts
+++ b/src/Quaternion.d.ts
@@ -60,19 +60,19 @@ interface Quaternion {
     IsNaN(this: Quaternion): boolean;
 
     ToCFrame(this: Quaternion, position?: Vector3): CFrame;
-    ToAxisAngle(this: Quaternion): (Vector3, number);
+    ToAxisAngle(this: Quaternion): LuaTuple<[Vector3, number]>;
     ToEulerVector(this: Quaternion): Vector3;
-    ToEulerAnglesXYZ(this: Quaternion): (number, number, number);
-    ToEulerAnglesYXZ(this: Quaternion): (number, number, number);
-    ToOrientation(this: Quaternion): (number, number, number);
-    ToEulerAngles(this: Quaternion, rotationOrder?: Enum.RotationOrder): (number, number, number);
-    ToMatrix(this: Quaternion): (number, number, number, number, number, number, number, number, number);
-    ToMatrixVectors(this: Quaternion): (Vector3, Vector3, Vector3);
+    ToEulerAnglesXYZ(this: Quaternion): LuaTuple<[number, number, number]>;
+    ToEulerAnglesYXZ(this: Quaternion): LuaTuple<[number, number, number]>;
+    ToOrientation(this: Quaternion): LuaTuple<[number, number, number]>;
+    ToEulerAngles(this: Quaternion, rotationOrder?: Enum.RotationOrder): LuaTuple<[number, number, number]>;
+    ToMatrix(this: Quaternion): LuaTuple<[number, number, number, number, number, number, number, number, number]>;
+    ToMatrixVectors(this: Quaternion): LuaTuple<[Vector3, Vector3, Vector3]>;
     Vector(this: Quaternion): Vector3;
     Scalar(this: Quaternion): number;
     Imaginary(this: Quaternion): Quaternion;
-    GetComponents(this: Quaternion): (number, number, number, number);
-    components(this: Quaternion): (number, number, number, number);
+    GetComponents(this: Quaternion): LuaTuple<[number, number, number, number]>;
+    components(this: Quaternion): LuaTuple<[number, number, number, number]>;
     ToString(this: Quaternion, decimalPlaces?: number): string;
 }
 

--- a/src/Quaternion.d.ts
+++ b/src/Quaternion.d.ts
@@ -77,23 +77,23 @@ interface Quaternion {
 }
 
 interface QuaternionConstructor {
-    new(qX: number?, qY: number?, qZ: number?, qW: number?): Quaternion;
-    fromAxisAngle(axis: Vector3, angle: number): Quaternion;
-    fromAxisAngleFast(axis: Vector3, angle: number): Quaternion;
-    fromEulerVector(eulerVector: Vector3): Quaternion;
-    fromCFrame(cframe: CFrame): Quaternion;
-    fromCFrameFast(cframe: CFrame): Quaternion;
-    fromMatrix(vX: Vector3, vY: Vector3, vZ: Vector3?): Quaternion;
-    fromMatrixFast(vX: Vector3, vY: Vector3, vZ: Vector3?): Quaternion;
-    lookAt(from: Vector3, lookAt: Vector3, up: Vector3?): Quaternion;
-    fromEulerAnglesXYZ(rx: number, ry: number, rz: number): Quaternion;
-    Angles(rx: number, ry: number, rz: number): Quaternion;
-    fromEulerAnglesYXZ(rx: number, ry: number, rz: number): Quaternion;
-    fromOrientation(rx: number, ry: number, rz: number): Quaternion;
-    fromEulerAngles(rx: number, ry: number, rz: number, rotationOrder: Enum.RotationOrder?): Quaternion;
-    fromVector(vector: Vector3, W: number?): Quaternion;
-    RandomQuaternion(seed: number): () => Quaternion;
-    
+    new: (qX?: number, qY?: number, qZ?: number, qW?: number) => Quaternion;
+    fromAxisAngle: (axis: Vector3, angle: number) => Quaternion;
+    fromAxisAngleFast: (axis: Vector3, angle: number) => Quaternion;
+    fromEulerVector: (eulerVector: Vector3) => Quaternion;
+    fromCFrame: (cframe: CFrame) => Quaternion;
+    fromCFrameFast: (cframe: CFrame) => Quaternion;
+    fromMatrix: (vX: Vector3, vY: Vector3, vZ?: Vector3) => Quaternion;
+    fromMatrixFast: (vX: Vector3, vY: Vector3, vZ?: Vector3) => Quaternion;
+    lookAt: (from: Vector3, lookAt: Vector3, up?: Vector3) => Quaternion;
+    fromEulerAnglesXYZ: (rx: number, ry: number, rz: number) => Quaternion;
+    Angles: (rx: number, ry: number, rz: number) => Quaternion;
+    fromEulerAnglesYXZ: (rx: number, ry: number, rz: number) => Quaternion;
+    fromOrientation: (rx: number, ry: number, rz: number) => Quaternion;
+    fromEulerAngles: (rx: number, ry: number, rz: number, rotationOrder?: Enum.RotationOrder) => Quaternion;
+    fromVector: (vector: Vector3, W?: number) => Quaternion;
+    RandomQuaternion: (seed: number) => () => Quaternion;
+
     identity: Quaternion;
     zero: Quaternion;
 }

--- a/src/Quaternion.d.ts
+++ b/src/Quaternion.d.ts
@@ -51,7 +51,7 @@ interface Quaternion {
     Slerp(this: Quaternion, q1: Quaternion, alpha: number): Quaternion;
     IdentitySlerp(q1: Quaternion, alpha: number): Quaternion;
     SlerpFunction(this: Quaternion, q1: Quaternion): (alpha: number) => Quaternion;
-    Intermediates(this: Quaternion, q1: Quaternion, n: number, includeEndpoints?: boolean): Quaternion;
+    Intermediates(this: Quaternion, q1: Quaternion, n: number, includeEndpoints?: boolean): Quaternion[];
     Derivative(this: Quaternion, rate: Vector3):  Quaternion;
     Integrate(this: Quaternion, rate: Vector3, timestep: number): Quaternion;
     AngularVelocity(this: Quaternion, q1: Quaternion, timestep: number): Vector3;

--- a/src/Quaternion.d.ts
+++ b/src/Quaternion.d.ts
@@ -51,7 +51,7 @@ interface Quaternion {
     Slerp(this: Quaternion, q1: Quaternion, alpha: number): Quaternion;
     IdentitySlerp(q1: Quaternion, alpha: number): Quaternion;
     SlerpFunction(this: Quaternion, q1: Quaternion): (alpha: number) => Quaternion;
-    Intermediates(this: Quaternion, q1: Quaternion, n: number, includeEndpoints: boolean?): {Quaternion};
+    Intermediates(this: Quaternion, q1: Quaternion, n: number, includeEndpoints?: boolean): {Quaternion};
     Derivative(this: Quaternion, rate: Vector3):  Quaternion;
     Integrate(this: Quaternion, rate: Vector3, timestep: number): Quaternion;
     AngularVelocity(this: Quaternion, q1: Quaternion, timestep: number): Vector3;
@@ -59,13 +59,13 @@ interface Quaternion {
     ApproxEq(this: Quaternion, q1: Quaternion, epsilon: number): boolean;
     IsNaN(this: Quaternion): boolean;
 
-    ToCFrame(this: Quaternion, position: Vector3?): CFrame;
+    ToCFrame(this: Quaternion, position?: Vector3): CFrame;
     ToAxisAngle(this: Quaternion): (Vector3, number);
     ToEulerVector(this: Quaternion): Vector3;
     ToEulerAnglesXYZ(this: Quaternion): (number, number, number);
     ToEulerAnglesYXZ(this: Quaternion): (number, number, number);
     ToOrientation(this: Quaternion): (number, number, number);
-    ToEulerAngles(this: Quaternion, rotationOrder: Enum.RotationOrder?): (number, number, number);
+    ToEulerAngles(this: Quaternion, rotationOrder?: Enum.RotationOrder): (number, number, number);
     ToMatrix(this: Quaternion): (number, number, number, number, number, number, number, number, number);
     ToMatrixVectors(this: Quaternion): (Vector3, Vector3, Vector3);
     Vector(this: Quaternion): Vector3;
@@ -73,7 +73,7 @@ interface Quaternion {
     Imaginary(this: Quaternion): Quaternion;
     GetComponents(this: Quaternion): (number, number, number, number);
     components(this: Quaternion): (number, number, number, number);
-    ToString(this: Quaternion, decimalPlaces: number?): string;
+    ToString(this: Quaternion, decimalPlaces?: number): string;
 }
 
 interface QuaternionConstructor {

--- a/src/Quaternion.d.ts
+++ b/src/Quaternion.d.ts
@@ -51,7 +51,7 @@ interface Quaternion {
     Slerp(this: Quaternion, q1: Quaternion, alpha: number): Quaternion;
     IdentitySlerp(q1: Quaternion, alpha: number): Quaternion;
     SlerpFunction(this: Quaternion, q1: Quaternion): (alpha: number) => Quaternion;
-    Intermediates(this: Quaternion, q1: Quaternion, n: number, includeEndpoints?: boolean): {Quaternion};
+    Intermediates(this: Quaternion, q1: Quaternion, n: number, includeEndpoints?: boolean): Quaternion;
     Derivative(this: Quaternion, rate: Vector3):  Quaternion;
     Integrate(this: Quaternion, rate: Vector3, timestep: number): Quaternion;
     AngularVelocity(this: Quaternion, q1: Quaternion, timestep: number): Vector3;

--- a/src/QuaternionSpring.d.ts
+++ b/src/QuaternionSpring.d.ts
@@ -5,7 +5,7 @@
 */
 
 interface QuaternionSpring {
-    Reset(this: QuaternionSpring, target: Quaternion?);
+    Reset(this: QuaternionSpring, target?: Quaternion);
     Impulse(this: QuaternionSpring, velocity: Vector3);
     TimeSkip(this: QuaternionSpring, delta: number);
     

--- a/src/QuaternionSpring.d.ts
+++ b/src/QuaternionSpring.d.ts
@@ -23,7 +23,7 @@ interface QuaternionSpring {
 }
 
 interface QuaternionSpringConstructor {
-    new(initial: Quaternion, damping: number, speed: number, clock: () => number): QuaternionSpring
+    new: (initial: Quaternion, damping: number, speed: number, clock: () => number) => QuaternionSpring;
 }
 
 declare const QuaternionSpring: QuaternionSpringConstructor;

--- a/src/RadianSpring.d.ts
+++ b/src/RadianSpring.d.ts
@@ -5,7 +5,7 @@
 */
 
 interface RadianSpring {
-    Reset(this: RadianSpring, target: number?);
+    Reset(this: RadianSpring, target?: number);
     Impulse(this: RadianSpring, velocity: number);
     TimeSkip(this: RadianSpring, delta: number);
     

--- a/src/RadianSpring.d.ts
+++ b/src/RadianSpring.d.ts
@@ -21,7 +21,7 @@ interface RadianSpring {
 }
 
 interface RadianSpringConstructor {
-    new(initial: number, damping: number, speed: number, min: number, max: number, clock: () => number): Spring
+    new: (initial: number, damping: number, speed: number, min: number, max: number, clock: () => number) => Spring;
 }
 
 declare const RadianSpring: RadianSpringConstructor;

--- a/src/Spring.d.ts
+++ b/src/Spring.d.ts
@@ -7,7 +7,7 @@
 type nlerpable = number | Vector2 | Vector3 | UDim | UDim2
 
 interface Spring<T = nlerpable> {
-    Reset(this: Spring, target: T?);
+    Reset(this: Spring, target?: T);
     Impulse(this: Spring, velocity: T);
     TimeSkip(this: Spring, delta: number);
     

--- a/src/Spring.d.ts
+++ b/src/Spring.d.ts
@@ -25,7 +25,7 @@ interface Spring<T = nlerpable> {
 }
 
 interface SpringConstructor<T = nlerpable> {
-    new(initial: T, damping: number, speed: number, clock: () => number): Spring
+    new: (initial: T, damping: number, speed: number, clock: () => number) => Spring;
 }
 
 declare const Spring: SpringConstructor;


### PR DESCRIPTION
This PR contains fixes for various translation issues for usage in TS. More specifically:

- #3 -> Constructor callbacks defined as method calls
- #4 -> Optional parameters are defined as optional type
- #6  -> Lua tuple return types defined as functions

Fixes #3
Fixes #4 
Fixes #6 